### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the school's GitHub Certifications program",
+        "schedule": "Saturdays, 10:00 AM - 12:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6 — The GitHub Skills activity announced by the principal was missing from the school activities signup page.

## Changes

- Added `GitHub Skills` to the activities list in `src/app.py`
- Description references the GitHub Certifications program as mentioned in the issue
- Capacity set to 25 participants
- Participants list starts empty so students can immediately begin registering

## Testing

The activity will appear in the `/activities` endpoint and be available for student signup immediately after deployment.